### PR TITLE
prepare for nightly builds

### DIFF
--- a/recipes/openms-meta/meta.yaml
+++ b/recipes/openms-meta/meta.yaml
@@ -1,22 +1,30 @@
 {% set name = "OpenMS" %}
-{% set version = "2.8.0" %}
+{% set version = "2.8.0dev" %}
 package:
   name: {{ name|lower  }}-meta
   version: {{ version  }}
 
 source:
-  url: https://abibuilder.informatik.uni-tuebingen.de/archive/openms/OpenMSInstaller/release/{{ version }}/OpenMS-{{ version }}-src.tar.gz
-  sha256: c39e3ccdce5c335d2659cfa9d0bb63555a01ec422757afd90706d3869bf611ac
+  git_url: https://github.com/OpenMS/OpenMS.git
+  git_rev: develop
+  git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  number: 1
+  number: 3
 
 # Try this when building with GUI
 #extra:
 #  container:
 #    extended-base: True
 
+# Unfortunately we can't include a dependency on the subpackages here
+# (probably bc of the jinja function in the compiler; but we need it
+# since this meta build prepares all the other builds and saves time)
+# Instead, we create an openms-full package later.
 requirements:
+    # build requirements should be loaded from the meta package already.
+    # But since the other packages depend on its run_exports
+    # We want to make sure that the versions of the dependencies used are the same as above
     build:
       - {{ compiler('cxx') }}
       - cmake
@@ -24,19 +32,20 @@ requirements:
       - autoconf
       - automake
     host:
+      # openms-general
       - llvm-openmp # [osx]
-      - zlib
+      - zlib >=1.2
       - libtool
-      - xerces-c
-      - boost-cpp
+      - xerces-c >=3.2
+      - boost-cpp >=1.60
       - eigen >=3.3.2
-      - glpk
+      - glpk >=4.45
       - hdf5 >=1.10
-      - bzip2
-      - qt
-      - libsvm
-      - coinmp
-      - sqlite
+      - bzip2 >=1.0
+      - qt >=5.5
+      - libsvm >=3.21
+      - coinmp >=1.8
+      - sqlite >=3.30
 
 test:
   commands:
@@ -53,20 +62,24 @@ outputs:
         # We want to make sure that the versions of the dependencies used are the same as above
         build:
           - cmake
+#         - {{ compiler('cxx') }}
+#         - make
+#         - autoconf
+#         - automake
         host:
           - llvm-openmp # [osx]
-          - zlib
+          - zlib >=1.2
           - libtool
-          - xerces-c
-          - boost-cpp
+          - xerces-c >=3.2
+          - boost-cpp >=1.60
           - eigen >=3.3.2
-          - glpk
+          - glpk >=4.45
           - hdf5 >=1.10
-          - bzip2
-          - qt
-          - libsvm
-          - coinmp
-          - sqlite
+          - bzip2 >=1.0
+          - qt >=5.5
+          - libsvm >=3.21
+          - coinmp >=1.8
+          - sqlite >=3.30     
     build:
       run_exports:
           - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
@@ -90,25 +103,25 @@ outputs:
       # no actual build is done. CMake is used to install different parts of the existing build
       build:
         - cmake
+#       - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage('libopenms', exact=True) }}
-      # conda apparently does not support run_exports in subpackages yet, otherwise having libopenms in host would be enough.
-      # see https://github.com/conda/conda-build/issues/3478
+      # conda apparently does not support run_exports in subpackages yet. https://github.com/conda/conda-build/issues/3478
       # so specify everything again, such that EXACTLY the same versions are used!
       # I could not get the "resolved_packages" jinja function to gather dependencies from other subpackages.
         - llvm-openmp # [osx]
-        - zlib
+        - zlib >=1.2
         - libtool
-        - xerces-c
-        - boost-cpp
+        - xerces-c >=3.2
+        - boost-cpp >=1.60
         - eigen >=3.3.2
-        - glpk
+        - glpk >=4.45
         - hdf5 >=1.10
-        - bzip2
-        - qt
-        - libsvm
-        - coinmp
-        - sqlite
+        - bzip2 >=1.0
+        - qt >=5.5
+        - libsvm >=3.21
+        - coinmp >=1.8
+        - sqlite >=3.30        
       run:
         - {{ pin_subpackage('libopenms', exact=True) }}
         - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
@@ -128,31 +141,86 @@ outputs:
         - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
         - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/FileMerger --help
 
-  - name: openms-thirdparty
-    version: {{ version }}
-    build:
-     # Dependencies bumbershoot, fido, percolator are not available for osx.
-     skip: True  # [osx]
-    requirements:
-     run:
-       - {{ pin_subpackage('openms', exact=True) }}
-       - bumbershoot ==3_0_21142_0e4f4a4
-       - comet-ms ==2019015
-       - crux-toolkit ==3.2
-       - fido ==1.0
-       - luciphor2 ==2020_04_03
-       - msgf_plus ==2021.03.22
-       - pepnovo ==20101117
-       - percolator ==3.5
-       - sirius-csifingerid ==4.9.8
-       - thermorawfileparser ==1.3.4
-       - xtandem ==15.12.15.2
-       - gnuplot
-       - r-gplots
-    test:
-     # Test copied from openms output to make sure a test environment for this output is created.
-     commands:
-       - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
+  # - name: pyopenms
+  #   version: {{ version }}
+  #   script: install_pyopenms.sh
+  #   # problem with pyopenms is: We could in theory skip CMake configuration
+  #   # and save a lot of build dependencies that are not in the API, BUT then env.py
+  #   # does not contain the right paths anymore, since the build folder is copied for each
+  #   # subpackage.
+  #   requirements:
+  #     build:
+  #       - {{ compiler('cxx') }}
+  #       - make
+  #       - cmake
+  #     host:
+  #       - {{ pin_subpackage('libopenms', exact=True) }}
+  #       - llvm-openmp # [osx]
+  #       - zlib >=1.2
+  #       - libtool
+  #       - xerces-c >=3.2
+  #       - boost-cpp >=1.60
+  #       - eigen >=3.3.2
+  #       - glpk >=4.45
+  #       - hdf5 >=1.10
+  #       - bzip2 >=1.0
+  #       - qt >=5.5
+  #       - libsvm >=3.21
+  #       - coinmp >=1.8
+  #       - sqlite >=3.30      
+  #       - python {{ python }}
+  #       - cython >=0.25.2
+  #       - autowrap >=0.22.6
+  #       - nose
+  #       - numpy {{ numpy }}
+  #       - pandas
+  #     run:
+  #       - {{ pin_subpackage('libopenms', exact=True) }}
+  #       - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
+  #       - {{ pin_compatible('zlib', max_pin='x.x') }}
+  #       - {{ pin_compatible('xerces-c', max_pin='x.x') }}
+  #       - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
+  #       - {{ pin_compatible('eigen', max_pin='x.x') }}
+  #       - {{ pin_compatible('glpk', max_pin='x.x') }}
+  #       - {{ pin_compatible('hdf5', max_pin='x.x') }}
+  #       - {{ pin_compatible('bzip2', max_pin='x.x') }}
+  #       - {{ pin_compatible('qt', max_pin='x.x') }}
+  #       - {{ pin_compatible('libsvm', max_pin='x.x') }}
+  #       - {{ pin_compatible('coinmp', max_pin='x.x') }}
+  #       - {{ pin_compatible('sqlite', max_pin='x.x') }}
+  #       - python {{ python }}
+  #       - numpy {{ numpy }}
+  #       - pandas
+  #   test:
+  #     commands:
+  #       - python -c "import pyopenms; print(pyopenms.__version__)"
+  #       # We cant use the PYTHON variable since it does not exist on the biocontainer?!
+
+#  - name: openms-thirdparty
+#    version: {{ version }}
+#    build:
+#      # Dependencies bumbershoot, fido, percolator are not available for osx.
+#      skip: True  # [osx]
+#    requirements:
+#      run:
+#        - {{ pin_subpackage('openms', exact=True) }}
+#        - bumbershoot ==3_0_20295_bfe5db0
+#        - comet-ms ==2019015
+#        - crux-toolkit ==3.2
+#        - fido ==1.0
+#        - luciphor2 ==2020_04_03
+#        - msgf_plus ==2021.03.22
+#        - pepnovo ==20101117
+#        - percolator ==3.5
+#        - sirius-csifingerid ==4.0.1
+#        - thermorawfileparser ==1.3.4
+#        - xtandem ==15.12.15.2
+#        - gnuplot
+#    test:
+#      # Test copied from openms output to make sure a test environment for this output is created.
+#      commands:
+#        - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
+#        - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/FileMerger --help
 
 about:
   home: https://github.com/OpenMS/OpenMS
@@ -163,6 +231,8 @@ about:
 extra:
   skip-lints:
     - build_number_needs_reset  # our linter has some issues with multi-package recipes as it seems
+    - uses_vcs_url  # only for nightly builds
+    - missing_hash  # only for nightly builds
   identifiers:
     - biotools:openms
     - usegalaxy-eu:openms_fileconverter

--- a/recipes/openms-meta/meta.yaml
+++ b/recipes/openms-meta/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "OpenMS" %}
-{% set version = "2.8.0dev" %}
+{% set version = "3.0.0dev" %}
 package:
   name: {{ name|lower  }}-meta
   version: {{ version  }}
@@ -10,21 +10,14 @@ source:
   git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  number: 3
+  number: 1
 
 # Try this when building with GUI
 #extra:
 #  container:
 #    extended-base: True
 
-# Unfortunately we can't include a dependency on the subpackages here
-# (probably bc of the jinja function in the compiler; but we need it
-# since this meta build prepares all the other builds and saves time)
-# Instead, we create an openms-full package later.
 requirements:
-    # build requirements should be loaded from the meta package already.
-    # But since the other packages depend on its run_exports
-    # We want to make sure that the versions of the dependencies used are the same as above
     build:
       - {{ compiler('cxx') }}
       - cmake
@@ -32,20 +25,19 @@ requirements:
       - autoconf
       - automake
     host:
-      # openms-general
       - llvm-openmp # [osx]
-      - zlib >=1.2
+      - zlib
       - libtool
-      - xerces-c >=3.2
-      - boost-cpp >=1.60
+      - xerces-c
+      - boost-cpp
       - eigen >=3.3.2
-      - glpk >=4.45
+      - glpk
       - hdf5 >=1.10
-      - bzip2 >=1.0
-      - qt >=5.5
-      - libsvm >=3.21
-      - coinmp >=1.8
-      - sqlite >=3.30
+      - bzip2
+      - qt
+      - libsvm
+      - coinmp
+      - sqlite
 
 test:
   commands:
@@ -62,24 +54,20 @@ outputs:
         # We want to make sure that the versions of the dependencies used are the same as above
         build:
           - cmake
-#         - {{ compiler('cxx') }}
-#         - make
-#         - autoconf
-#         - automake
         host:
           - llvm-openmp # [osx]
-          - zlib >=1.2
+          - zlib
           - libtool
-          - xerces-c >=3.2
-          - boost-cpp >=1.60
+          - xerces-c
+          - boost-cpp
           - eigen >=3.3.2
-          - glpk >=4.45
+          - glpk
           - hdf5 >=1.10
-          - bzip2 >=1.0
-          - qt >=5.5
-          - libsvm >=3.21
-          - coinmp >=1.8
-          - sqlite >=3.30     
+          - bzip2
+          - qt
+          - libsvm
+          - coinmp
+          - sqlite
     build:
       run_exports:
           - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
@@ -103,25 +91,25 @@ outputs:
       # no actual build is done. CMake is used to install different parts of the existing build
       build:
         - cmake
-#       - {{ compiler('cxx') }}
       host:
         - {{ pin_subpackage('libopenms', exact=True) }}
-      # conda apparently does not support run_exports in subpackages yet. https://github.com/conda/conda-build/issues/3478
+      # conda apparently does not support run_exports in subpackages yet, otherwise having libopenms in host would be enough.
+      # see https://github.com/conda/conda-build/issues/3478
       # so specify everything again, such that EXACTLY the same versions are used!
       # I could not get the "resolved_packages" jinja function to gather dependencies from other subpackages.
         - llvm-openmp # [osx]
-        - zlib >=1.2
+        - zlib
         - libtool
-        - xerces-c >=3.2
-        - boost-cpp >=1.60
+        - xerces-c
+        - boost-cpp
         - eigen >=3.3.2
-        - glpk >=4.45
+        - glpk
         - hdf5 >=1.10
-        - bzip2 >=1.0
-        - qt >=5.5
-        - libsvm >=3.21
-        - coinmp >=1.8
-        - sqlite >=3.30        
+        - bzip2
+        - qt
+        - libsvm
+        - coinmp
+        - sqlite
       run:
         - {{ pin_subpackage('libopenms', exact=True) }}
         - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
@@ -141,86 +129,31 @@ outputs:
         - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
         - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/FileMerger --help
 
-  # - name: pyopenms
-  #   version: {{ version }}
-  #   script: install_pyopenms.sh
-  #   # problem with pyopenms is: We could in theory skip CMake configuration
-  #   # and save a lot of build dependencies that are not in the API, BUT then env.py
-  #   # does not contain the right paths anymore, since the build folder is copied for each
-  #   # subpackage.
-  #   requirements:
-  #     build:
-  #       - {{ compiler('cxx') }}
-  #       - make
-  #       - cmake
-  #     host:
-  #       - {{ pin_subpackage('libopenms', exact=True) }}
-  #       - llvm-openmp # [osx]
-  #       - zlib >=1.2
-  #       - libtool
-  #       - xerces-c >=3.2
-  #       - boost-cpp >=1.60
-  #       - eigen >=3.3.2
-  #       - glpk >=4.45
-  #       - hdf5 >=1.10
-  #       - bzip2 >=1.0
-  #       - qt >=5.5
-  #       - libsvm >=3.21
-  #       - coinmp >=1.8
-  #       - sqlite >=3.30      
-  #       - python {{ python }}
-  #       - cython >=0.25.2
-  #       - autowrap >=0.22.6
-  #       - nose
-  #       - numpy {{ numpy }}
-  #       - pandas
-  #     run:
-  #       - {{ pin_subpackage('libopenms', exact=True) }}
-  #       - {{ pin_compatible('llvm-openmp', max_pin='x.x') }} # [osx]
-  #       - {{ pin_compatible('zlib', max_pin='x.x') }}
-  #       - {{ pin_compatible('xerces-c', max_pin='x.x') }}
-  #       - {{ pin_compatible('boost-cpp', max_pin='x.x') }}
-  #       - {{ pin_compatible('eigen', max_pin='x.x') }}
-  #       - {{ pin_compatible('glpk', max_pin='x.x') }}
-  #       - {{ pin_compatible('hdf5', max_pin='x.x') }}
-  #       - {{ pin_compatible('bzip2', max_pin='x.x') }}
-  #       - {{ pin_compatible('qt', max_pin='x.x') }}
-  #       - {{ pin_compatible('libsvm', max_pin='x.x') }}
-  #       - {{ pin_compatible('coinmp', max_pin='x.x') }}
-  #       - {{ pin_compatible('sqlite', max_pin='x.x') }}
-  #       - python {{ python }}
-  #       - numpy {{ numpy }}
-  #       - pandas
-  #   test:
-  #     commands:
-  #       - python -c "import pyopenms; print(pyopenms.__version__)"
-  #       # We cant use the PYTHON variable since it does not exist on the biocontainer?!
-
-#  - name: openms-thirdparty
-#    version: {{ version }}
-#    build:
-#      # Dependencies bumbershoot, fido, percolator are not available for osx.
-#      skip: True  # [osx]
-#    requirements:
-#      run:
-#        - {{ pin_subpackage('openms', exact=True) }}
-#        - bumbershoot ==3_0_20295_bfe5db0
-#        - comet-ms ==2019015
-#        - crux-toolkit ==3.2
-#        - fido ==1.0
-#        - luciphor2 ==2020_04_03
-#        - msgf_plus ==2021.03.22
-#        - pepnovo ==20101117
-#        - percolator ==3.5
-#        - sirius-csifingerid ==4.0.1
-#        - thermorawfileparser ==1.3.4
-#        - xtandem ==15.12.15.2
-#        - gnuplot
-#    test:
-#      # Test copied from openms output to make sure a test environment for this output is created.
-#      commands:
-#        - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
-#        - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/FileMerger --help
+  - name: openms-thirdparty
+    version: {{ version }}
+    build:
+     # Dependencies bumbershoot, fido, percolator are not available for osx.
+     skip: True  # [osx]
+    requirements:
+     run:
+       - {{ pin_subpackage('openms', exact=True) }}
+       - bumbershoot ==3_0_21142_0e4f4a4
+       - comet-ms ==2019015
+       - crux-toolkit ==3.2
+       - fido ==1.0
+       - luciphor2 ==2020_04_03
+       - msgf_plus ==2021.03.22
+       - pepnovo ==20101117
+       - percolator ==3.5
+       - sirius-csifingerid ==4.9.8
+       - thermorawfileparser ==1.3.4
+       - xtandem ==15.12.15.2
+       - gnuplot
+       - r-gplots
+    test:
+     # Test copied from openms output to make sure a test environment for this output is created.
+     commands:
+       - OPENMS_DATA_PATH=${PREFIX}/share/OpenMS/ ${PREFIX}/bin/OpenMSInfo
 
 about:
   home: https://github.com/OpenMS/OpenMS

--- a/recipes/openms-meta/meta.yaml
+++ b/recipes/openms-meta/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
-  number: 1
+  number: 0
 
 # Try this when building with GUI
 #extra:

--- a/recipes/pyopenms/meta.yaml
+++ b/recipes/pyopenms/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyopenms" %}
-{% set version = "2.8.0dev" %}
+{% set version = "3.0.0dev" %}
 package:
   name: {{ name|lower  }}
   version: {{ version  }}

--- a/recipes/pyopenms/meta.yaml
+++ b/recipes/pyopenms/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "pyopenms" %}
-{% set version = "2.8.0" %}
+{% set version = "2.8.0dev" %}
 package:
   name: {{ name|lower  }}
   version: {{ version  }}
 
 source:
-  url: https://abibuilder.informatik.uni-tuebingen.de/archive/openms/OpenMSInstaller/release/{{ version }}/OpenMS-{{ version }}-src.tar.gz
-  sha256: c39e3ccdce5c335d2659cfa9d0bb63555a01ec422757afd90706d3869bf611ac
-  patches:
-    - pyopenms_cmakelist2.patch
-    - pyopenms_cmakelist.patch
+  git_url: https://github.com/OpenMS/OpenMS.git
+  git_rev: develop
+  git_depth: 1 # (Defaults to -1/not shallow)
 
 build:
   skip: True  # [py2k]
@@ -61,6 +59,10 @@ about:
   summary: python bindings for OpenMS, an open-source software C++ library for LC-MS data management and analyses
 
 extra:
+  skip-lints:
+    - build_number_needs_reset  # our linter has some issues with multi-package recipes as it seems
+    - uses_vcs_url  # only for nightly builds
+    - missing_hash  # only for nightly builds
   identifiers:
     - biotools:openms
     - doi:10.1038/nmeth.3959


### PR DESCRIPTION
To provide nightly conda builds we need to change the recipes.
This PR moves the patches from jpfeuffer/bioconda-recipes nightly branch to the OpenMS organization.
