### PR TITLE
pyopenms: merge duplicate skip-lints entries

### DIFF
--- a/recipes/pyopenms/meta.yaml
+++ b/recipes/pyopenms/meta.yaml
@@ -74,12 +74,11 @@ extra:
     # repeatedly tripped CircleCI arm.large infrastructure_fail (not a recipe issue;
     # it builds fine locally within the runner's memory and time budget).
     - osx-arm64
-{% if "dev" in version %}
-  skip-lints:
-    - uses_vcs_url
-{% endif %}
   identifiers:
     - biotools:openms
     - doi:10.1038/s41592-024-02197-7
   skip-lints:
+{% if "dev" in version %}
+    - uses_vcs_url
+{% endif %}
     - compiler_needs_stdlib_c


### PR DESCRIPTION
## Summary

- emit a single `extra.skip-lints` key in the pyOpenMS recipe
- retain `uses_vcs_url` for development versions
- retain `compiler_needs_stdlib_c` for every version

## Root cause

The `nightly` recipe sets the version to `3.6.0dev`, which activates the conditional `uses_vcs_url` block. After the upstream recipe added a second unconditional `skip-lints` key, the rendered nightly YAML contained duplicate keys and `bioconda-utils lint` aborted before either package could build.

## Impact

This restores the lint gate used by OpenMS's `Deploy to Bioconda` workflow so nightly `pyopenms` and `openms-meta` builds can proceed.

Related issue: OpenMS/OpenMS#9897

## Validation

- `git diff --check -- recipes/pyopenms/meta.yaml`
- rendered both stable and development forms with strict `ruamel.yaml` duplicate-key parsing
- `bioconda-utils lint --packages pyopenms openms-meta` with Python 3.12 and `bioconda-utils 4.1.0`, matching the latest failing workflow: `All checks OK`

The existing non-fatal `openms-meta` `long_summary` warning remains.